### PR TITLE
nowa在September 23, 2011将此句去掉，但实际测试表明初次创

### DIFF
--- a/lib/redis/search/base.rb
+++ b/lib/redis/search/base.rb
@@ -34,7 +34,7 @@ class Redis
             exts
           end
 
-          # after_create :redis_search_index_create
+          after_create :redis_search_index_create
           def redis_search_index_create
             s = Search::Index.new(:title => self.#{title_field}, 
                                   :id => self.id, 


### PR DESCRIPTION
nowa在September 23, 2011将此句去掉，但实际测试表明初次创建记录时redis_search_index_need_reindex返回false，从而不会触发index的创建。原因在于新纪录不能保证_changed?返回true
