### PR TITLE
fix constants name error with redis-rails & redis-store

### DIFF
--- a/lib/redis/search/base.rb
+++ b/lib/redis/search/base.rb
@@ -1,7 +1,8 @@
 # coding: utf-8
+
 class Redis
   module Search
-    extend ActiveSupport::Concern
+    extend ::ActiveSupport::Concern
 
     module ClassMethods
       # Config redis-search index for Model

--- a/lib/redis/search/railtie.rb
+++ b/lib/redis/search/railtie.rb
@@ -1,6 +1,6 @@
 class Redis
   module Search
-    class Railtie < Rails::Railtie
+    class Railtie < ::Rails::Railtie
       rake_tasks do
         load File.expand_path('../tasks.rb', __FILE__)
       end


### PR DESCRIPTION
和redis-rails或redis-store一起工作时会有问题
因为redis-rails中有Redis::Rails类，所以在Redis class下Rails其实是Redis::Rails，这样Rails::Railtie其实是Redis::Rails::Railtie，会报错NameError

redis-store在Redis下会有Redis::ActiveSupport类，所以同上ActiveSupport::Concern其实是Redis::ActiveSupport::Concern也会NameError

这两个gem用的还是很广的。。所以在这里fix吧
