### PR TITLE
增加一个的 type 设置

### DIFF
--- a/lib/redis/search/base.rb
+++ b/lib/redis/search/base.rb
@@ -20,6 +20,7 @@ class Redis
         ext_fields          = options[:ext_fields] || []
         score_field         = options[:score_field] || :created_at
         condition_fields    = options[:condition_fields] || []
+        type                = options[:type] || self.name
 
         # Add score field to ext_fields
         ext_fields |= [score_field]
@@ -58,7 +59,7 @@ class Redis
                                   :aliases => self.redis_search_alias_value(#{alias_field.inspect}),
                                   :id => self.id,
                                   :exts => self.redis_search_fields_to_hash(#{ext_fields.inspect}),
-                                  :type => self.class.to_s,
+                                  :type => #{type},
                                   :condition_fields => #{condition_fields},
                                   :score => self.#{score_field}.to_i,
                                   :prefix_index_enable => #{prefix_index_enable})

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -43,4 +43,12 @@ describe Redis::Search do
       User.count.should == User.redis_search_index_batch_create(1000, true)
     end
   end
+
+  describe 'redis search index type' do
+    it 'allow set type for index' do
+      Admin.create(:email => "zsf@gmail.com", :sex => 1, :name => "张三丰", :alias => ["张三疯","张麻子"], :score => 100, :password => "123456")
+      Redis::Search.complete("User","zsf").count.should == 1
+    end
+  end
 end
+

--- a/spec/models.rb
+++ b/spec/models.rb
@@ -44,7 +44,8 @@ class User
                      :score_field => :score,
                      :condition_fields => [:sex],
                      :prefix_index_enable => true,
-                     :ext_fields => [:email])
+                     :ext_fields => [:email],
+                     :model_name => 'User')
 end
 
 class Category
@@ -57,4 +58,7 @@ class Category
   redis_search_index(:title_field => :name,
                      :prefix_index_enable => true,
                      :ext_fields => [])
+end
+
+class Admin < User
 end


### PR DESCRIPTION
在使用单表继承的情况下，不同 type 的 model 会被分开来索引，增加一个 type 设置把这些 model 的索引放到一起
